### PR TITLE
fix: AOT bundle on non-x64 hosts (arm64, riscv64)

### DIFF
--- a/lib/src/aot/aot_builder.dart
+++ b/lib/src/aot/aot_builder.dart
@@ -89,7 +89,7 @@ class AotBuilder {
       'cache',
       'artifacts',
       'engine',
-      'linux-x64',
+      '${host.os.configToken}-${host.flutterArch}',
     ),
   );
   Directory get _engineCommon => Directory(
@@ -104,6 +104,15 @@ class AotBuilder {
   );
   String get _dartSdkBin =>
       p.join(workspace.flutterDir.path, 'bin', 'cache', 'dart-sdk', 'bin');
+
+  /// Host-arch AOT `frontend_server` snapshot shipped with the Dart SDK.
+  ///
+  /// The engine-artifacts copy (`artifacts/engine/<host>/`) is built on x64 CI
+  /// and is x86-64 even inside the `linux-arm64` bundle, so it can't run under
+  /// the arm64 `dartaotruntime`. The `dart-sdk/bin/snapshots/` copy is always
+  /// host-arch — this is the one modern Flutter itself uses.
+  String get _frontendServerAot =>
+      p.join(_dartSdkBin, 'snapshots', 'frontend_server_aot.dart.snapshot');
 
   /// Run `flutter build bundle --<mode>` to produce `build/flutter_assets`.
   ///
@@ -149,9 +158,7 @@ class AotBuilder {
       ]);
     }
 
-    final newScheme = File(
-      p.join(_hostEngine.path, 'frontend_server_aot.dart.snapshot'),
-    ).existsSync();
+    final newScheme = File(_frontendServerAot).existsSync();
     final targetArch = arch ?? host.machineArch;
     final gen = genSnapshot ?? await _resolveGenSnapshot(targetArch, modes);
 
@@ -253,12 +260,9 @@ class AotBuilder {
     final dartRuntime = newScheme
         ? p.join(_dartSdkBin, 'dartaotruntime')
         : p.join(_dartSdkBin, 'dart');
-    final frontend = p.join(
-      _hostEngine.path,
-      newScheme
-          ? 'frontend_server_aot.dart.snapshot'
-          : 'frontend_server.dart.snapshot',
-    );
+    final frontend = newScheme
+        ? _frontendServerAot
+        : p.join(_hostEngine.path, 'frontend_server.dart.snapshot');
     final depfile = p.join(
       buildDir,
       newScheme ? 'kernel_snapshot_program.d' : 'kernel_snapshot.d',

--- a/test/src/aot/aot_builder_test.dart
+++ b/test/src/aot/aot_builder_test.dart
@@ -14,6 +14,22 @@ const _host = HostInfo(
   versionId: '43',
 );
 
+const _armHost = HostInfo(
+  os: HostOs.linux,
+  machineArch: 'aarch64',
+  archAliases: {'arm64', 'aarch64'},
+  hostType: 'fedora',
+  versionId: '43',
+);
+
+const _riscvHost = HostInfo(
+  os: HostOs.linux,
+  machineArch: 'riscv64',
+  archAliases: {'riscv64'},
+  hostType: 'fedora',
+  versionId: '43',
+);
+
 /// Records every process invocation and returns success; simulates the build
 /// dir + app.dill appearing after `flutter build bundle`.
 class _Recorder {
@@ -45,8 +61,8 @@ void main() {
 
   // Native x86_64 build: target == host, so the resolver picks the host SDK
   // cache gen_snapshot directly (no artifact/probe needed).
-  AotBuilder builder(Directory ws, _Recorder rec) =>
-      AotBuilder(Workspace(ws), host: _host, runProcess: rec.run);
+  AotBuilder builder(Directory ws, _Recorder rec, {HostInfo host = _host}) =>
+      AotBuilder(Workspace(ws), host: host, runProcess: rec.run);
 
   void writeApp(Directory app, {String name = 'myapp'}) {
     app.createSync(recursive: true);
@@ -54,8 +70,9 @@ void main() {
   }
 
   // Create a fake new-scheme SDK cache so the builder picks dartaotruntime +
-  // frontend_server_aot and finds a host gen_snapshot.
-  void writeSdk(Directory ws) {
+  // frontend_server_aot and finds a host gen_snapshot. [engineDir] is the
+  // host engine-artifacts dir name (`linux-x64`, `linux-arm64`, …).
+  void writeSdk(Directory ws, {String engineDir = 'linux-x64'}) {
     final hostEngine = p.join(
       ws.path,
       'flutter',
@@ -63,13 +80,26 @@ void main() {
       'cache',
       'artifacts',
       'engine',
-      'linux-x64',
+      engineDir,
     );
     Directory(hostEngine).createSync(recursive: true);
-    File(
-      p.join(hostEngine, 'frontend_server_aot.dart.snapshot'),
-    ).writeAsStringSync('x');
     File(p.join(hostEngine, 'gen_snapshot')).writeAsStringSync('x');
+    // The new-scheme frontend_server_aot snapshot lives in the Dart SDK and is
+    // always host-arch — unlike the engine-artifacts copy, which is x64 even
+    // inside the linux-arm64 bundle.
+    final snapshots = p.join(
+      ws.path,
+      'flutter',
+      'bin',
+      'cache',
+      'dart-sdk',
+      'bin',
+      'snapshots',
+    );
+    Directory(snapshots).createSync(recursive: true);
+    File(
+      p.join(snapshots, 'frontend_server_aot.dart.snapshot'),
+    ).writeAsStringSync('x');
     Directory(
       p.join(
         ws.path,
@@ -116,7 +146,52 @@ void main() {
       kernel.args.any((a) => a.contains('flutter_patched_sdk_product')),
       isTrue,
     );
+
+    // x86_64 host: frontend_server comes from the Dart SDK (host-arch). The
+    // gen_snapshot call above succeeding also proves _hostEngine resolved to
+    // linux-x64, where writeSdk placed it.
+    final frontend = kernel.args.firstWhere(
+      (a) => a.endsWith('frontend_server_aot.dart.snapshot'),
+    );
+    expect(frontend, contains(p.join('dart-sdk', 'bin', 'snapshots')));
   });
+
+  // Regression: on a non-x64 host the engine-artifacts dir is e.g.
+  // `linux-arm64`/`linux-riscv64` (not `linux-x64`), and its
+  // frontend_server_aot snapshot is an x64 binary the host dartaotruntime can't
+  // run. The builder must resolve the host engine dir from the host arch and
+  // take frontend_server from the Dart SDK (host-arch).
+  for (final (host, engineDir) in [
+    (_armHost, 'linux-arm64'),
+    (_riscvHost, 'linux-riscv64'),
+  ]) {
+    test('${host.machineArch} host resolves $engineDir engine + '
+        'dart-sdk frontend_server', () async {
+      final ws = Directory(p.join(tmp.path, 'ws'))..createSync();
+      final app = Directory(p.join(tmp.path, 'app'));
+      writeApp(app);
+      writeSdk(ws, engineDir: engineDir);
+      final rec = _Recorder(app.path);
+
+      final result = await builder(
+        ws,
+        rec,
+        host: host,
+      ).build(appPath: app.path, modes: const ['release']);
+
+      // Succeeds only if _hostEngine resolved to [engineDir] (gen_snapshot is
+      // written there) — proving the arch-derived path fix.
+      expect(result.success, isTrue);
+
+      final kernel = rec.calls.firstWhere((c) => c.exe == 'dartaotruntime');
+      final frontend = kernel.args.firstWhere(
+        (a) => a.endsWith('frontend_server_aot.dart.snapshot'),
+      );
+      // Host-arch snapshot from the Dart SDK, not the x64 engine copy.
+      expect(frontend, contains(p.join('dart-sdk', 'bin', 'snapshots')));
+      expect(frontend, isNot(contains(p.join('artifacts', 'engine'))));
+    });
+  }
 
   test('fails cleanly when pubspec has no name', () async {
     final ws = Directory(p.join(tmp.path, 'ws'))..createSync();


### PR DESCRIPTION
## Problem

`emb bundle --build` fails on an arm64 host:

```
Could not find a command named ".../engine/linux-x64/frontend_server.dart.snapshot".
✗ Bundle failed
kernel snapshot failed
```

The AOT builder hardcoded the host engine-artifacts directory to `linux-x64`, which does not exist on non-x64 hosts.

## Fix

Two arch assumptions in `lib/src/aot/aot_builder.dart`:

1. **`_hostEngine` path** — now derived from the detected host as `<os.configToken>-<flutterArch>` (e.g. `linux-arm64`, `linux-riscv64`, `darwin-arm64`) instead of a
fixed `linux-x64`. Using `configToken` (not `os.name`) maps macOS to `darwin`, matching Flutter's artifact naming.

2. **`frontend_server_aot.dart.snapshot` source** — now taken from `dart-sdk/bin/snapshots/`, which is always host-arch (the location modern Flutter itself uses).
Flutter's arm64 engine zip ships an **x86-64** `frontend_server_aot.dart.snapshot` under `linux-arm64`, which the arm64 `dartaotruntime` cannot run (`is not an AOT
snapshot`). On x64 the engine-artifacts copy happened to match the host arch and worked by luck.

## Tests

Regression tests cover engine-dir resolution and host-arch `frontend_server` selection for **arm64** and **riscv64** hosts; the existing x86_64 test now also asserts
the Dart SDK `frontend_server` path.

## Verification

Reproduced and confirmed fixed on an arm64 host — `emb bundle ... --build` now succeeds and produces a genuine arm64 `libapp.so` (ELF ARM aarch64). `dart analyze`
clean, full `test/src/aot/` suite passes.