### PR TITLE
feat(config): filter legacy configs by load; add --enable/--disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ One-shot provision: **deps → repos → Flutter SDK → engine**, then writes
 |---|---|---|
 | `-c`, `--config <dir>` | `configs` | Legacy JSON config directory. |
 | `-p`, `--packages <dir>` | — | Directory to discover self-describing `emb` manifests. |
+| `--enable <id>` | — | Force-load the config with this `id` (overrides `load: false`). Repeatable; unmatched ids ignored. |
+| `--disable <id>` | — | Skip the config with this `id` (overrides `load: true`). Repeatable; unmatched ids ignored. |
 | `-w`, `--workspace <dir>` | resolution order | Workspace root. |
 | `--flutter-version <ref>` | `globals.json` `flutter_version` | Flutter version/tag/branch. |
 | `--arch <arch>` | host arch | Engine arch to prefetch. |
@@ -160,7 +162,13 @@ One-shot provision: **deps → repos → Flutter SDK → engine**, then writes
 ```sh
 emb setup --config ../configs --yes
 emb setup --config ../configs --skip-deps --skip-sync   # SDK + engine only
+emb setup --config ../configs --enable weston --disable agl-compositor
 ```
+
+> **Config selection** (applies to `setup`, `deps`, and `sync`): legacy
+> `--config` components apply only when their `load` flag is logically true.
+> `--enable <id>` / `--disable <id>` override that per component, matched by
+> `id`; ids matching nothing are ignored, and load order is preserved.
 
 ---
 
@@ -173,6 +181,8 @@ Coalesce host dependencies across all selected manifests, filter to what's
 |---|---|---|
 | `-c`, `--config <dir>` | `configs` | Legacy JSON config directory. **Repeatable.** |
 | `-p`, `--packages <dir>` | — | Directory to discover self-describing `emb` manifests. **Repeatable.** |
+| `--enable <id>` | — | Force-load the config with this `id` (overrides `load: false`). Repeatable; unmatched ids ignored. |
+| `--disable <id>` | — | Skip the config with this `id` (overrides `load: true`). Repeatable; unmatched ids ignored. |
 | `--dry-run` | off | Resolve and print the install plan without changing the system. |
 | `-y`, `--yes` | off | Skip the confirmation prompt (CI). |
 
@@ -191,6 +201,8 @@ Clone/update source repositories into `<workspace>/app` (bounded concurrency).
 |---|---|---|
 | `-c`, `--config <dir>` | `configs` | Legacy JSON config directory. **Repeatable.** |
 | `-p`, `--packages <dir>` | — | Directory to discover self-describing `emb` manifests. |
+| `--enable <id>` | — | Force-load the config with this `id` (overrides `load: false`). Repeatable; unmatched ids ignored. |
+| `--disable <id>` | — | Skip the config with this `id` (overrides `load: true`). Repeatable; unmatched ids ignored. |
 | `--repos <file>` | — | A JSON file containing a bare array of repo entries. **Repeatable.** |
 | `-w`, `--workspace <dir>` | resolution order | Workspace root. |
 | `-j`, `--concurrency <n>` | `4` | Maximum concurrent git operations. |

--- a/lib/src/commands/deps_command.dart
+++ b/lib/src/commands/deps_command.dart
@@ -37,6 +37,18 @@ class DepsCommand extends Command<int> {
             'Directory to discover self-describing emb manifests '
             '(repeatable).',
       )
+      ..addMultiOption(
+        'enable',
+        help:
+            'Force-load the config with this id (overrides load: false). '
+            'Repeatable; ids that match nothing are ignored.',
+      )
+      ..addMultiOption(
+        'disable',
+        help:
+            'Skip the config with this id (overrides load: true). '
+            'Repeatable; ids that match nothing are ignored.',
+      )
       ..addFlag(
         'dry-run',
         help: 'Resolve and print the install plan without changing the system.',
@@ -68,13 +80,18 @@ class DepsCommand extends Command<int> {
     final host = _host ?? HostInfo.detect();
 
     // ── Load manifests ────────────────────────────────────────────────────
-    final manifests = <EmbManifest>[];
+    final raw = <EmbManifest>[];
     for (final dir in args['config'] as List<String>) {
-      manifests.addAll(_loader.loadConfigDir(Directory(dir)));
+      raw.addAll(_loader.loadConfigDir(Directory(dir)));
     }
     for (final dir in args['packages'] as List<String>) {
-      manifests.addAll(_loader.discoverPackages(Directory(dir)));
+      raw.addAll(_loader.discoverPackages(Directory(dir)));
     }
+    final manifests = _loader.select(
+      raw,
+      enable: (args['enable'] as List<String>).toSet(),
+      disable: (args['disable'] as List<String>).toSet(),
+    );
 
     if (manifests.isEmpty) {
       _logger.warn(

--- a/lib/src/commands/setup_command.dart
+++ b/lib/src/commands/setup_command.dart
@@ -48,6 +48,18 @@ class SetupCommand extends Command<int> {
         abbr: 'p',
         help: 'Directory to discover self-describing manifests.',
       )
+      ..addMultiOption(
+        'enable',
+        help:
+            'Force-load the config with this id (overrides load: false). '
+            'Repeatable; ids that match nothing are ignored.',
+      )
+      ..addMultiOption(
+        'disable',
+        help:
+            'Skip the config with this id (overrides load: true). '
+            'Repeatable; ids that match nothing are ignored.',
+      )
       ..addOption(
         'workspace',
         abbr: 'w',
@@ -110,13 +122,18 @@ class SetupCommand extends Command<int> {
     final workspace = Workspace.resolve(override: args['workspace'] as String?);
     final configDirs = args['config'] as List<String>;
 
-    final manifests = <EmbManifest>[];
+    final raw = <EmbManifest>[];
     for (final dir in configDirs) {
-      manifests.addAll(_loader.loadConfigDir(Directory(dir)));
+      raw.addAll(_loader.loadConfigDir(Directory(dir)));
     }
     for (final dir in args['packages'] as List<String>) {
-      manifests.addAll(_loader.discoverPackages(Directory(dir)));
+      raw.addAll(_loader.discoverPackages(Directory(dir)));
     }
+    final manifests = _loader.select(
+      raw,
+      enable: (args['enable'] as List<String>).toSet(),
+      disable: (args['disable'] as List<String>).toSet(),
+    );
 
     _logger.info(
       styleBold.wrap(

--- a/lib/src/commands/sync_command.dart
+++ b/lib/src/commands/sync_command.dart
@@ -35,6 +35,18 @@ class SyncCommand extends Command<int> {
         help: 'Directory to discover self-describing emb manifests.',
       )
       ..addMultiOption(
+        'enable',
+        help:
+            'Force-load the config with this id (overrides load: false). '
+            'Repeatable; ids that match nothing are ignored.',
+      )
+      ..addMultiOption(
+        'disable',
+        help:
+            'Skip the config with this id (overrides load: true). '
+            'Repeatable; ids that match nothing are ignored.',
+      )
+      ..addMultiOption(
         'repos',
         help:
             'A JSON file containing a bare array of repo entries '
@@ -69,13 +81,18 @@ class SyncCommand extends Command<int> {
     final workspace = Workspace.resolve(override: args['workspace'] as String?);
 
     // Collect repos from manifests' `src` lists.
-    final manifests = <EmbManifest>[];
+    final raw = <EmbManifest>[];
     for (final dir in args['config'] as List<String>) {
-      manifests.addAll(_loader.loadConfigDir(Directory(dir)));
+      raw.addAll(_loader.loadConfigDir(Directory(dir)));
     }
     for (final dir in args['packages'] as List<String>) {
-      manifests.addAll(_loader.discoverPackages(Directory(dir)));
+      raw.addAll(_loader.discoverPackages(Directory(dir)));
     }
+    final manifests = _loader.select(
+      raw,
+      enable: (args['enable'] as List<String>).toSet(),
+      disable: (args['disable'] as List<String>).toSet(),
+    );
 
     final repos = <GitRepo>[];
     for (final m in manifests) {

--- a/lib/src/manifest/emb_manifest.dart
+++ b/lib/src/manifest/emb_manifest.dart
@@ -37,7 +37,7 @@ class EmbManifest {
     return EmbManifest(
       id: (map['id'] ?? '') as String,
       type: (map['type'] ?? 'app') as String,
-      load: (map['load'] ?? true) as bool,
+      load: _truthy(map['load']),
       supportedArchs: _stringList(
         map['supported_archs'] ?? map['supportedArchs'],
       ),
@@ -124,6 +124,18 @@ class EmbManifest {
       return value.map((k, v) => MapEntry(k.toString(), v.toString()));
     }
     return const {};
+  }
+
+  /// Whether a `load` value is logically true. Defaults to true when absent,
+  /// and accepts bool/number/string forms so legacy configs can't crash the
+  /// loader. Only explicit false-y values (`false`, `0`, `no`, `off`, empty)
+  /// turn a component off.
+  static bool _truthy(dynamic value) {
+    if (value == null) return true;
+    if (value is bool) return value;
+    if (value is num) return value != 0;
+    const falsey = {'false', '0', 'no', 'off', ''};
+    return !falsey.contains(value.toString().trim().toLowerCase());
   }
 
   @override

--- a/lib/src/manifest/manifest_loader.dart
+++ b/lib/src/manifest/manifest_loader.dart
@@ -38,6 +38,24 @@ class ManifestLoader {
   /// Load a single legacy JSON config file.
   EmbManifest? loadConfigFile(File file) => _tryLoadJson(file);
 
+  /// Select the manifests that should apply, honoring each manifest's `load`
+  /// flag and explicit [enable]/[disable] overrides matched by
+  /// [EmbManifest.id].
+  ///
+  /// A manifest applies when its id is in [enable], or its `load` is true and
+  /// its id is not in [disable]. So `--enable` forces a `load: false` component
+  /// on, `--disable` forces a `load: true` one off, and `enable` wins if an id
+  /// is in both. Ids in [enable]/[disable] that match no manifest are ignored.
+  /// The occurrence order of [manifests] is preserved.
+  List<EmbManifest> select(
+    List<EmbManifest> manifests, {
+    Set<String> enable = const {},
+    Set<String> disable = const {},
+  }) => [
+    for (final m in manifests)
+      if (enable.contains(m.id) || (m.load && !disable.contains(m.id))) m,
+  ];
+
   /// Load a self-describing manifest from a package directory: prefers
   /// `emb.yaml`, falls back to an `emb:` key in `pubspec.yaml`. Returns null
   /// if neither is present.

--- a/test/src/manifest/manifest_loader_test.dart
+++ b/test/src/manifest/manifest_loader_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:emb_cli/src/host/host_info.dart';
+import 'package:emb_cli/src/manifest/emb_manifest.dart';
 import 'package:emb_cli/src/manifest/manifest_loader.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -92,5 +93,63 @@ emb:
   test('skips malformed JSON without throwing', () {
     File(p.join(tmp.path, 'bad.json')).writeAsStringSync('{not valid');
     expect(loader.loadConfigDir(tmp), isEmpty);
+  });
+
+  group('select (load + enable/disable)', () {
+    EmbManifest mk(String id, {Object? load}) => EmbManifest.fromMap(
+      <String, dynamic>{'id': id, if (load != null) 'load': load},
+    );
+
+    test('defaults to only load:true manifests', () {
+      final ms = [mk('a'), mk('b', load: false), mk('c', load: true)];
+      expect(loader.select(ms).map((m) => m.id), ['a', 'c']);
+    });
+
+    test('--enable forces a load:false component on', () {
+      final ms = [mk('a', load: false), mk('b', load: false)];
+      expect(loader.select(ms, enable: {'a'}).map((m) => m.id), ['a']);
+    });
+
+    test('--disable forces a load:true component off', () {
+      final ms = [mk('a'), mk('b')];
+      expect(loader.select(ms, disable: {'a'}).map((m) => m.id), ['b']);
+    });
+
+    test('enable wins when an id is both enabled and disabled', () {
+      final ms = [mk('a', load: false)];
+      final got = loader.select(ms, enable: {'a'}, disable: {'a'});
+      expect(got.map((m) => m.id), ['a']);
+    });
+
+    test('unmatched enable/disable ids are ignored', () {
+      final ms = [mk('a'), mk('b', load: false)];
+      final got = loader.select(ms, enable: {'nope'}, disable: {'ghost'});
+      expect(got.map((m) => m.id), ['a']);
+    });
+
+    test('preserves occurrence order', () {
+      final ms = [mk('z'), mk('a'), mk('m')];
+      expect(loader.select(ms).map((m) => m.id), ['z', 'a', 'm']);
+    });
+  });
+
+  group('load truthiness', () {
+    bool loadOf(Object? v) =>
+        EmbManifest.fromMap(<String, dynamic>{'id': 'x', 'load': v}).load;
+
+    test('absent load defaults to true', () {
+      expect(EmbManifest.fromMap(<String, dynamic>{'id': 'x'}).load, isTrue);
+    });
+
+    test('only explicit false-y values turn a component off', () {
+      expect(loadOf(false), isFalse);
+      expect(loadOf('false'), isFalse);
+      expect(loadOf('off'), isFalse);
+      expect(loadOf(0), isFalse);
+      expect(loadOf(''), isFalse);
+      expect(loadOf(true), isTrue);
+      expect(loadOf('true'), isTrue);
+      expect(loadOf(1), isTrue);
+    });
   });
 }


### PR DESCRIPTION
## What

Make `--config` JSON components opt-in by their `load` flag, with explicit
per-component overrides — so `emb setup`/`deps`/`sync` only act on the
components you actually want.

- **Default:** a legacy `--config` component applies only when its `load` flag
  is **logically true**.
- **`--enable <id>`** forces a `load: false` component on.
- **`--disable <id>`** forces a `load: true` component off.
- Matched by `id`; ids that match no component are **ignored** (no error).
- `enable` wins if an id is in both. **Occurrence order is preserved.**
- Repeatable; wired into **`setup`**, **`deps`**, and **`sync`**.

```sh
emb setup --config ../configs                               # only load:true
emb setup --config ../configs --enable weston               # + a load:false one
emb setup --config ../configs --disable agl-compositor      # - a load:true one
```

## Robustness

`load` parsing now accepts bool / number / string forms (`true`, `"false"`,
`0`, `"off"`, …), so a legacy config with a non-boolean `load` can't crash the
loader; only explicit false-y values turn a component off.

## Implementation

- `ManifestLoader.select(manifests, {enable, disable})` — pure, order-preserving
  selection; commands load (`loadConfigDir` + `discoverPackages`) then `select`.
- `EmbManifest._truthy` for the tolerant `load` parse.

## Tests / CI

- New `select` group (default / enable / disable / enable-wins / unmatched /
  order) + `load` truthiness cases.
- Full suite: 85 passing. Coverage **47.32%** (was 46.76%) — over the 45 gate.
- `dart format` / `dart analyze` clean; cspell clean.

## Docs

README command reference updated: `--enable`/`--disable` rows on `setup`,
`deps`, `sync`, plus a "Config selection" note.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
