### PR TITLE
fix(git): support post-checkout hooks; verify checkout by HEAD

### DIFF
--- a/lib/src/repo/git_repo.dart
+++ b/lib/src/repo/git_repo.dart
@@ -88,9 +88,9 @@ class GitRepo {
       }
 
       if (rev != null) {
-        await _run(runner, ['checkout', rev!], gitFolder);
+        await _checkout(runner, rev!, gitFolder);
       } else if (branch != null) {
-        await _run(runner, ['checkout', branch!], gitFolder);
+        await _checkout(runner, branch!, gitFolder);
       }
 
       if (File(p.join(gitFolder, '.gitattributes')).existsSync()) {
@@ -119,6 +119,38 @@ class GitRepo {
         message: e.message,
       );
     }
+  }
+
+  /// Check out [ref] (a branch, tag, or commit), tolerating a failing
+  /// `post-checkout` hook.
+  ///
+  /// `post-checkout` runs *after* the worktree is updated, and per
+  /// githooks(5) its exit status becomes the exit status of `git checkout`.
+  /// So a hook that fails — e.g. Flutter's monorepo hooks call depot_tools'
+  /// `vpython3`, which may be absent — makes the command report failure even
+  /// though the checkout itself succeeded. Judge the result by HEAD instead:
+  /// if it resolves to [ref]'s commit, the checkout landed and the hook's
+  /// exit status is not a checkout failure.
+  Future<void> _checkout(GitRunner runner, String ref, String cwd) async {
+    final r = await runner(['checkout', ref], workingDirectory: cwd);
+    if (r.exitCode == 0) return;
+    if (await _headIsAt(runner, ref, cwd)) return;
+    throw _GitException(
+      'git checkout $ref failed (${r.exitCode}): ${r.stderr}',
+    );
+  }
+
+  /// Whether HEAD now resolves to the same commit as [ref].
+  Future<bool> _headIsAt(GitRunner runner, String ref, String cwd) async {
+    final head = await runner(['rev-parse', 'HEAD'], workingDirectory: cwd);
+    final target = await runner([
+      'rev-parse',
+      '$ref^{commit}',
+    ], workingDirectory: cwd);
+    if (head.exitCode != 0 || target.exitCode != 0) return false;
+    final headSha = '${head.stdout}'.trim();
+    final targetSha = '${target.stdout}'.trim();
+    return headSha.isNotEmpty && headSha == targetSha;
   }
 
   Future<void> _run(

--- a/test/src/repo/git_repo_test.dart
+++ b/test/src/repo/git_repo_test.dart
@@ -9,6 +9,7 @@ import 'package:test/test.dart';
 class _FakeGit {
   final List<List<String>> calls = [];
   int Function(List<String> args)? exitFor;
+  String Function(List<String> args)? stdoutFor;
 
   Future<ProcessResult> run(
     List<String> args, {
@@ -16,7 +17,8 @@ class _FakeGit {
   }) async {
     calls.add(args);
     final code = exitFor?.call(args) ?? 0;
-    return ProcessResult(0, code, '', '');
+    final out = stdoutFor?.call(args) ?? '';
+    return ProcessResult(0, code, out, '');
   }
 }
 
@@ -107,6 +109,43 @@ void main() {
       await repo.sync(tmp, runner: git.run);
       expect(git.calls, contains(equals(['checkout', 'abc123'])));
       expect(git.calls, isNot(contains(equals(['checkout', 'main']))));
+    });
+
+    test('tolerates a failed post-checkout hook when HEAD landed', () async {
+      Directory(p.join(tmp.path, 'foo', '.git')).createSync(recursive: true);
+      // checkout exits non-zero (hook adopted its status), but HEAD and the
+      // requested rev resolve to the same commit -> the checkout succeeded.
+      int checkoutFails(List<String> a) => a.first == 'checkout' ? 1 : 0;
+      String sameSha(List<String> a) =>
+          a.first == 'rev-parse' ? 'cafe1234' : '';
+      final git = _FakeGit()
+        ..exitFor = checkoutFails
+        ..stdoutFor = sameSha;
+      const repo = GitRepo(uri: 'https://x/y/foo.git', rev: 'v1');
+      final result = await repo.sync(tmp, runner: git.run);
+
+      expect(result.success, isTrue);
+      expect(git.calls, contains(equals(['rev-parse', 'HEAD'])));
+      expect(git.calls, contains(equals(['rev-parse', 'v1^{commit}'])));
+    });
+
+    test('reports failure when checkout does not land on the ref', () async {
+      Directory(p.join(tmp.path, 'foo', '.git')).createSync(recursive: true);
+      // checkout exits non-zero AND HEAD != ref -> a genuine failure.
+      int checkoutFails(List<String> a) => a.first == 'checkout' ? 1 : 0;
+      String mismatchedSha(List<String> a) {
+        if (a.first != 'rev-parse') return '';
+        return a.contains('HEAD') ? 'aaaa' : 'bbbb';
+      }
+
+      final git = _FakeGit()
+        ..exitFor = checkoutFails
+        ..stdoutFor = mismatchedSha;
+      const repo = GitRepo(uri: 'https://x/y/foo.git', rev: 'v1');
+      final result = await repo.sync(tmp, runner: git.run);
+
+      expect(result.success, isFalse);
+      expect(result.message, contains('checkout v1 failed'));
     });
   });
 }


### PR DESCRIPTION
## What

Make `emb`'s git checkout tolerant of `post-checkout` hooks, so `emb flutter` /
`emb sync` no longer fail when a cloned repo runs a hook that exits non-zero.

## The failing sequence

```console
$ emb setup --config ../configs --yes --flutter-version 3.44.2
...
▸ Flutter SDK
✗   Flutter SDK install failed (1.0s)
git checkout 3.44.2 failed (1): HEAD is now at c9a6c484230 Update `engine.version` for 3.44.2 stable release (#187805)
env: 'vpython3': No such file or directory
```

The Flutter clone sets `core.hooksPath` to `engine/src/flutter/tools/githooks`,
whose `post-checkout` hook shells out to depot_tools' `vpython3` — absent here,
so the hook exits non-zero.

## Root cause

Per githooks(5), `post-checkout` runs **after** the worktree is updated, and its
exit status **becomes** the exit status of `git checkout`. So a failing
post-step makes `git checkout` return non-zero **even though the checkout
succeeded** — note `HEAD is now at c9a6c484230` in the output above.

`GitRepo` treated any non-zero exit as a checkout failure, aborting the whole
operation on a checkout that had actually landed. And this isn't Flutter-
specific: any cloned repo may carry a `post-checkout` hook.

## The fix

Judge checkout success by **whether HEAD now resolves to the requested ref's
commit**, not by the raw exit code:

- exit 0 -> success;
- non-zero but `HEAD == <ref>^{commit}` -> the checkout landed (a post-checkout
  hook merely failed) -> success;
- non-zero and HEAD elsewhere -> a genuine failure, still reported.

Hooks still run — only their post-step exit status no longer aborts a checkout
that succeeded.

## Validation

- Empirical: a throwaway repo with a deliberately-failing `post-checkout` hook —
  `git checkout v1` exits 1, but HEAD lands on `v1` (confirms the premise).
- Unit tests: hook-failed-but-HEAD-landed -> success; non-zero-and-HEAD-elsewhere
  -> failure; plus the existing exit-0 path.
- `dart format` / `dart analyze` clean; full suite passing; coverage over the 45
  gate.

No behavior change for repos without hooks.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
