### PR TITLE
fix(cross): normalize usr-merge after -dev staging; surface overlay build errors

### DIFF
--- a/lib/src/cross/arm_gnu_cross_provider.dart
+++ b/lib/src/cross/arm_gnu_cross_provider.dart
@@ -251,8 +251,16 @@ class ArmGnuCrossProvider implements CrossProvider {
 
     // Layer the `-dev` packages in, root-free (download + dpkg-deb -x).
     if (spec.devPackages.isNotEmpty) {
-      return _populateDevPackages(sysrootDir, spec);
+      final err = await _populateDevPackages(sysrootDir, spec);
+      if (err != null) return err;
     }
+
+    // Restore Debian's usr-merge symlinks (/lib -> usr/lib, …) *after* all
+    // staging. debugfs mangles them on extraction, and `dpkg-deb -x` of the
+    // `-dev` set re-materializes them as real dirs — either leaves libc.so's
+    // `/lib/...` linker-script refs unresolved and silently poisons every
+    // configure that probes the sysroot (e.g. meson's `find_library('m')`).
+    normalizeUsrMerge(sysrootDir);
     return null;
   }
 
@@ -434,9 +442,6 @@ class ArmGnuCrossProvider implements CrossProvider {
         'debugfs rdump did not populate ${dest.path}',
       );
     }
-    // debugfs can mangle the usr-merge symlinks (/lib -> usr/lib); restore them
-    // so libc.so's /lib/... references resolve inside the sysroot.
-    normalizeUsrMerge(dest);
     return null;
   }
 

--- a/lib/src/cross/overlay_builder.dart
+++ b/lib/src/cross/overlay_builder.dart
@@ -88,15 +88,22 @@ class OverlayBuilder {
 
     for (final lib in libs) {
       if (await _satisfied(lib)) continue;
-      final ok = switch (lib.build) {
-        CrossGenerator.meson => await _buildMeson(lib, overlay),
-        CrossGenerator.cmake => await _buildCMake(lib, overlay),
-      };
-      if (!ok) {
-        throw OverlayBuildException('failed to build ${lib.pkg} into overlay');
+      switch (lib.build) {
+        case CrossGenerator.meson:
+          await _buildMeson(lib, overlay);
+        case CrossGenerator.cmake:
+          await _buildCMake(lib, overlay);
       }
     }
     return paths;
+  }
+
+  /// A fresh build dir for [src] — wiped first so a re-run never reuses a stale
+  /// (possibly mis-configured) meson/cmake cache.
+  Directory _freshBuildDir(Directory src) {
+    final bld = Directory(p.join(src.path, '_build'));
+    if (bld.existsSync()) bld.deleteSync(recursive: true);
+    return bld..createSync();
   }
 
   /// True when the sysroot already provides [lib] at >= its `min` version.
@@ -133,9 +140,9 @@ class OverlayBuilder {
     return dir;
   }
 
-  Future<bool> _buildMeson(AugmentLib lib, Directory overlay) async {
+  Future<void> _buildMeson(AugmentLib lib, Directory overlay) async {
     final src = await _fetchSource(lib);
-    final bld = Directory(p.join(src.path, '_build'))..createSync();
+    final bld = _freshBuildDir(src);
     // Prefer the profile's meson cross file; else emit one from its fields.
     final cross =
         profile.mesonCrossFile ??
@@ -161,19 +168,22 @@ class OverlayBuilder {
       '--default-library',
       if (lib.staticLink) 'static' else 'shared',
     ], environment: profile.buildEnv());
-    if (setup.exitCode != 0) return false;
-    if ((await _run('ninja', ['-C', bld.path])).exitCode != 0) return false;
-    final install = await _run(
-      'ninja',
-      ['-C', bld.path, 'install'],
-      environment: {...profile.buildEnv(), 'DESTDIR': overlay.path},
+    _check(lib, 'meson setup', setup);
+    _check(lib, 'ninja', await _run('ninja', ['-C', bld.path]));
+    _check(
+      lib,
+      'ninja install',
+      await _run(
+        'ninja',
+        ['-C', bld.path, 'install'],
+        environment: {...profile.buildEnv(), 'DESTDIR': overlay.path},
+      ),
     );
-    return install.exitCode == 0;
   }
 
-  Future<bool> _buildCMake(AugmentLib lib, Directory overlay) async {
+  Future<void> _buildCMake(AugmentLib lib, Directory overlay) async {
     final src = await _fetchSource(lib);
-    final bld = Directory(p.join(src.path, '_build'))..createSync();
+    final bld = _freshBuildDir(src);
     final tc = profile.cmakeToolchainFile;
     final configure = await _run('cmake', [
       '-S',
@@ -184,15 +194,29 @@ class OverlayBuilder {
       '-DCMAKE_INSTALL_PREFIX=/usr',
       '-DCMAKE_BUILD_TYPE=Release',
     ], environment: profile.buildEnv());
-    if (configure.exitCode != 0) return false;
+    _check(lib, 'cmake configure', configure);
     // Header-only (e.g. Vulkan-Headers) installs with no build step.
-    final install = await _run('cmake', [
-      '--install',
-      bld.path,
-      '--prefix',
-      p.join(overlay.path, 'usr'),
-    ], environment: profile.buildEnv());
-    return install.exitCode == 0;
+    _check(
+      lib,
+      'cmake install',
+      await _run('cmake', [
+        '--install',
+        bld.path,
+        '--prefix',
+        p.join(overlay.path, 'usr'),
+      ], environment: profile.buildEnv()),
+    );
+  }
+
+  /// Throw with the failing [step]'s stderr so an overlay failure is
+  /// actionable rather than a bare "failed to build into overlay".
+  void _check(AugmentLib lib, String step, ProcessResult r) {
+    if (r.exitCode == 0) return;
+    final detail = '${r.stderr}'.trim();
+    throw OverlayBuildException(
+      '${lib.pkg}: $step failed (exit ${r.exitCode})'
+      '${detail.isEmpty ? '' : '\n$detail'}',
+    );
   }
 
   Future<void> _download(String url, File dest) async {

--- a/test/src/cross/arm_gnu_cross_provider_test.dart
+++ b/test/src/cross/arm_gnu_cross_provider_test.dart
@@ -52,6 +52,41 @@ void main() {
     return r;
   }
 
+  test('resolve restores usr-merge symlinks after staging', () async {
+    // The post-extraction/post-dpkg-deb-x state: /lib is a real dir while the
+    // real libs live under usr/lib/<multiarch>. resolve() must normalize it so
+    // a configure that probes the sysroot (meson's find_library('m')) works.
+    prestage('12.3.rel1');
+    final sr = p.join(
+      tmp.path,
+      '.config',
+      'flutter_workspace',
+      'cross-$_triple',
+      'sysroot',
+    );
+    File(p.join(sr, 'usr', 'lib', 'aarch64-linux-gnu', 'libc.so.6'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync('');
+    File(p.join(sr, 'lib', 'systemd', 'x'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync('');
+
+    final r = await resolveTarget(
+      CrossTarget.fromMap({
+        'provider': 'arm-gnu',
+        'toolchain_version': '12.3.rel1',
+        'image_url': 'https://example/x.img.xz',
+      }),
+    );
+
+    expect(r.ok, isTrue, reason: r.message);
+    expect(FileSystemEntity.isLinkSync(p.join(sr, 'lib')), isTrue);
+    expect(
+      File(p.join(sr, 'lib', 'aarch64-linux-gnu', 'libc.so.6')).existsSync(),
+      isTrue,
+    );
+  });
+
   test('pinned: resolves a pre-staged toolchain + sysroot', () async {
     prestage('12.3.rel1');
     final r = await resolveTarget(


### PR DESCRIPTION
## Summary

A fresh `emb cross <pkg> --build` failed at `augment: failed to build
libdisplay-info into overlay`. Two issues, one a real bug and one that made it
hard to diagnose.

**The bug.** The arm-gnu sysroot's Debian usr-merge symlinks (`/lib` →
`usr/lib`, …) were restored with `normalizeUsrMerge` immediately after the base
image extraction — but `_populateDevPackages` (`dpkg-deb -x` of the `-dev` set)
runs *afterward* and re-materializes `/lib` as a real directory (tar replaces a
directory-over-symlink). So by the time the augment / embedder configured, the
sysroot's `/lib` was broken again. That silently poisons every configure step
that probes the sysroot: meson's `find_library('m')` failed, `libdisplay-info`
linked its tools without `-lm`, and the build died with `undefined reference to
powf/sqrtf`.

**The diagnosis pain.** `OverlayBuilder` swallowed the meson/ninja stderr and
reported only `failed to build <pkg> into overlay`, with no detail.

## Fix

- Move `normalizeUsrMerge(sysrootDir)` to the **end of `_prepareSysroot`**, so
  it runs after *all* staging (extraction + `-dev` population) and covers every
  acquisition path (image / device). Removed the now-redundant call in
  `_extractImageRootless`.
- `OverlayBuilder` is now actionable: it **wipes a stale `_build`** before each
  configure (a re-run never reuses a mis-configured meson/cmake cache), and
  **throws with the failing step's stderr** instead of the blind message.

## Validation

- New regression test: `resolve()` restores a clobbered `/lib` real-dir into a
  `usr/lib` symlink.
- End-to-end on a fresh workspace: clean reconfigure reports `Library m found:
  YES`, the augment builds, and `emb cross --build` produces an `ELF 64-bit
  aarch64` `homescreen` (exit 0).
- `dart analyze` clean, `dart format` clean, full suite green (167 tests).

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
