### PR TITLE
fix: don't auto-install shell completion on every run

### DIFF
--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -54,6 +54,13 @@ class EmbCliCommandRunner extends CompletionCommandRunner<int> {
   @override
   void printUsage() => _logger.info(usage);
 
+  // Don't write shell-completion files on every invocation. The auto-installer
+  // targets $XDG_CONFIG_HOME, which a workspace setup_env.sh can point into the
+  // build tree (a fragile, sometimes non-directory path) — failing noisily on
+  // an unrelated command. Users opt in with `emb install-completion-files`.
+  @override
+  bool get enableAutoInstall => false;
+
   final Logger _logger;
   final PubUpdater _pubUpdater;
 

--- a/test/src/command_runner_test.dart
+++ b/test/src/command_runner_test.dart
@@ -43,6 +43,12 @@ void main() {
       );
     });
 
+    test('does not auto-install shell completion', () {
+      // Auto-install writes to $XDG_CONFIG_HOME and can fail noisily on an
+      // unrelated command; users opt in explicitly instead.
+      expect(commandRunner.enableAutoInstall, isFalse);
+    });
+
     test('shows update message when newer version exists', () async {
       when(
         () => pubUpdater.getLatestVersion(any()),


### PR DESCRIPTION
## Summary

Running any command — even `emb --help` — could fail with:

```
FileSystemException: Creation failed, path =
'…/.config/flutter/.dart-cli-completion' (OS Error: Not a directory, errno = 20)
```

`EmbCliCommandRunner` extends `CompletionCommandRunner`, which **auto-installs
shell-completion files on every invocation**, writing under `$XDG_CONFIG_HOME`.
A workspace `setup_env.sh` can point `XDG_CONFIG_HOME` into the build tree, where
a path component is sometimes a file rather than a directory — so the completion
installer throws on an unrelated command.

## Fix

Disable the per-run auto-install:

```dart
@override
bool get enableAutoInstall => false;
```

Completion is still available on demand via `emb install-completion-files`
(and the `completion` subcommand is unaffected).

## Validation

- Repro: with a file at the `$XDG_CONFIG_HOME` path (forcing `errno 20`),
  `emb --help` no longer emits the `FileSystemException` and prints usage
  normally.
- New test asserts `enableAutoInstall` is `false`.
- `dart analyze` clean, `dart format` clean, command-runner tests pass.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
