### PR TITLE
feat(cross): --app assembles a runnable bundle (embedder + engine + app)

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,9 @@ emb cross <package-dir|manifest.yaml> [options]
 | `--build` | off | Configure + build the embedder under the resolved profile, one build per `cross.backends` entry. |
 | `--backend <name>` | all | Build only the named `cross.backends` entries. Repeatable. |
 | `--deb` | off | With `--build`: package each backend binary into a root-free `.deb` (Depends auto-derived from the binary's needed libraries). |
+| `--app <dir>` | — | With `--build`: also build this Flutter app for the target and assemble a **runnable bundle** (embedder + engine + flutter_assets + icudtl + libapp), runnable as `./homescreen --b=.`. |
+| `-m`, `--mode <mode>` | `release` | Runtime mode for the `--app` bundle (`debug`/`profile`/`release`). |
+| `--tar` | off | Also produce a `.tar.gz` of each runnable bundle. |
 | `--clean` | off | Remove this target's build + overlay dirs (keeps the toolchain + sysroot), then exit. |
 | `--clean-all` | off | Also remove the downloaded / extracted toolchain + sysroot and the apt / deb caches, then exit. |
 

--- a/lib/src/commands/cross_command.dart
+++ b/lib/src/commands/cross_command.dart
@@ -1,6 +1,9 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:emb_cli/src/aot/aot_builder.dart';
+import 'package:emb_cli/src/bundle/bundle_builder.dart';
+import 'package:emb_cli/src/bundle/bundle_pipeline.dart';
 import 'package:emb_cli/src/cross/cross_arch.dart';
 import 'package:emb_cli/src/cross/cross_builder.dart';
 import 'package:emb_cli/src/cross/cross_keys.dart';
@@ -10,6 +13,8 @@ import 'package:emb_cli/src/cross/cross_target.dart';
 import 'package:emb_cli/src/cross/deb_packager.dart';
 import 'package:emb_cli/src/cross/local_cross_provider.dart';
 import 'package:emb_cli/src/cross/overlay_builder.dart';
+import 'package:emb_cli/src/cross/runnable_bundle.dart';
+import 'package:emb_cli/src/engine/engine_artifacts.dart';
 import 'package:emb_cli/src/host/host_info.dart';
 import 'package:emb_cli/src/manifest/manifest_loader.dart';
 import 'package:emb_cli/src/workspace/workspace.dart';
@@ -30,9 +35,15 @@ class CrossCommand extends Command<int> {
     required Logger logger,
     HostInfo? host,
     ManifestLoader loader = const ManifestLoader(),
+    AotBuilder Function(Workspace ws, HostInfo host)? aotFactory,
+    BundleBuilder Function(Workspace ws)? bundleFactory,
+    EngineArtifacts Function(Workspace ws)? engineFactory,
   }) : _logger = logger,
        _host = host,
-       _loader = loader {
+       _loader = loader,
+       _aotFactory = aotFactory ?? ((ws, h) => AotBuilder(ws, host: h)),
+       _bundleFactory = bundleFactory ?? BundleBuilder.new,
+       _engineFactory = engineFactory ?? EngineArtifacts.new {
     argParser
       ..addOption(
         'workspace',
@@ -96,12 +107,33 @@ class CrossCommand extends Command<int> {
             'Also remove the downloaded/extracted toolchain + sysroot (and '
             'apt/deb caches) for this target, then exit.',
         negatable: false,
+      )
+      ..addOption(
+        'app',
+        help:
+            'With --build: also build this Flutter app for the target and '
+            'assemble a runnable bundle (embedder + engine + assets + libapp).',
+      )
+      ..addOption(
+        'mode',
+        abbr: 'm',
+        allowed: ['debug', 'profile', 'release'],
+        defaultsTo: 'release',
+        help: 'Runtime mode for the --app bundle.',
+      )
+      ..addFlag(
+        'tar',
+        help: 'Also produce a .tar.gz of each runnable bundle.',
+        negatable: false,
       );
   }
 
   final Logger _logger;
   final HostInfo? _host;
   final ManifestLoader _loader;
+  final AotBuilder Function(Workspace ws, HostInfo host) _aotFactory;
+  final BundleBuilder Function(Workspace ws) _bundleFactory;
+  final EngineArtifacts Function(Workspace ws) _engineFactory;
 
   @override
   String get name => 'cross';
@@ -261,9 +293,13 @@ class CrossCommand extends Command<int> {
         target,
         workspace,
         inputPath,
+        host: host,
         deb: args['deb'] == true,
         defaultName: manifest.id,
         selectedBackends: selectedBackends,
+        appPath: args['app'] as String?,
+        mode: args['mode'] as String,
+        tar: args['tar'] == true,
       );
     }
     return ExitCode.success.code;
@@ -320,9 +356,13 @@ class CrossCommand extends Command<int> {
     CrossTarget target,
     Workspace workspace,
     String inputPath, {
+    required HostInfo host,
     bool deb = false,
     String defaultName = 'app',
     List<String> selectedBackends = const [],
+    String? appPath,
+    String mode = 'release',
+    bool tar = false,
   }) async {
     final source =
         FileSystemEntity.typeSync(inputPath) == FileSystemEntityType.file
@@ -392,15 +432,26 @@ class CrossCommand extends Command<int> {
       }
     }
     if (!results.every((r) => r.success)) return ExitCode.software.code;
+    final built = results.where((r) => r.success).toList();
 
-    if (deb) {
-      return _packageDebs(
+    // Assemble a runnable bundle (embedder + engine + assets + libapp).
+    if (appPath != null) {
+      final rc = await _runnable(
         profile,
         target,
         buildRoot,
-        results.where((r) => r.success).toList(),
-        defaultName,
+        built,
+        host: host,
+        workspace: workspace,
+        appPath: appPath,
+        mode: mode,
+        tar: tar,
       );
+      if (rc != ExitCode.success.code) return rc;
+    }
+
+    if (deb) {
+      return _packageDebs(profile, target, buildRoot, built, defaultName);
     }
     return ExitCode.success.code;
   }
@@ -475,6 +526,93 @@ class CrossCommand extends Command<int> {
       i++;
     }
     return '${n.toStringAsFixed(i == 0 || n >= 100 ? 0 : 1)}${units[i]}';
+  }
+
+  /// Build [appPath] for the target arch, then assemble a runnable bundle per
+  /// built backend — the embedder binary beside the engine + flutter_assets +
+  /// icudtl + libapp — under `<buildRoot>/runnable[-<backend>]`.
+  Future<int> _runnable(
+    CrossProfile profile,
+    CrossTarget target,
+    Directory buildRoot,
+    List<CrossBuildResult> built, {
+    required HostInfo host,
+    required Workspace workspace,
+    required String appPath,
+    required String mode,
+    required bool tar,
+  }) async {
+    final arch = EngineArtifacts.engineArch(archOfTriple(profile.targetTriple));
+
+    // Build the app bundle once (engine fetch + AOT + assemble).
+    final appBundle = Directory(
+      p.join(buildRoot.path, 'app-bundle-$mode-$arch'),
+    );
+    final progress = _logger.progress('Building app bundle ($mode/$arch)');
+    final res = await buildAndAssemble(
+      workspace: workspace,
+      aot: _aotFactory(workspace, host),
+      bundle: _bundleFactory(workspace),
+      engine: _engineFactory(workspace),
+      appPath: appPath,
+      arch: arch,
+      mode: mode,
+      outputDir: appBundle.path,
+      build: true,
+      onStep: progress.update,
+    );
+    if (!res.success) {
+      progress.fail(res.message ?? 'app bundle build failed');
+      return ExitCode.software.code;
+    }
+    progress.complete('App bundle ready → ${res.outputDir}');
+
+    final runnable = RunnableBundle();
+    for (final r in built) {
+      final binary = _artifactFor(r.buildDir, target.package?.bin);
+      if (binary == null) {
+        _logger.err(
+          '  ${r.backend ?? ""}: no embedder binary in ${r.buildDir} '
+          '(set cross.package.bin)',
+        );
+        return ExitCode.software.code;
+      }
+      final multi = built.length > 1 && r.backend != null;
+      final outDir = Directory(
+        p.join(buildRoot.path, multi ? 'runnable-${r.backend}' : 'runnable'),
+      );
+      if (outDir.existsSync()) outDir.deleteSync(recursive: true);
+      await _copyTree(appBundle, outDir);
+      try {
+        final bin = await runnable.install(binary, outDir);
+        _logger.info(
+          '  ${r.backend ?? ""}: runnable → ${outDir.path}  '
+          '(run: ./${p.basename(bin.path)} --b=.)',
+        );
+        if (tar) {
+          final archive = await runnable.tar(outDir);
+          _logger.info('  ${r.backend ?? ""}: ${archive.path}');
+        }
+      } on RunnableBundleException catch (e) {
+        _logger.err('  ${r.backend ?? ""}: ${e.message}');
+        return ExitCode.software.code;
+      }
+    }
+    return ExitCode.success.code;
+  }
+
+  /// Recursively copy the contents of [src] into [dst] (preserving symlinks +
+  /// mode), via `cp -a`.
+  Future<void> _copyTree(Directory src, Directory dst) async {
+    dst.createSync(recursive: true);
+    final r = await Process.run('cp', [
+      '-a',
+      '.',
+      dst.path,
+    ], workingDirectory: src.path);
+    if (r.exitCode != 0) {
+      throw RunnableBundleException('copy failed: ${r.stderr}');
+    }
   }
 
   /// Package each successfully-built backend binary into a `.deb` under

--- a/lib/src/cross/runnable_bundle.dart
+++ b/lib/src/cross/runnable_bundle.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:emb_cli/src/cross/process_runner.dart';
+import 'package:path/path.dart' as p;
+
+/// Combines a cross-built embedder binary with an assembled Flutter app bundle
+/// into one runnable tree:
+///
+/// ```text
+/// <dir>/
+///   homescreen                       # the cross-built embedder
+///   data/flutter_assets/ …
+///   data/icudtl.dat
+///   lib/libapp.so                    # AOT app (profile/release)
+///   lib/libflutter_engine.so         # target-arch engine
+/// ```
+///
+/// Run on the target as `./homescreen --b=<dir>`. The `data/` + `lib/` halves
+/// come from the bundle pipeline; this just drops the embedder in beside them.
+class RunnableBundle {
+  RunnableBundle({ProcessRunner runProcess = defaultProcessRunner})
+    : _run = runProcess;
+
+  final ProcessRunner _run;
+
+  /// Copy [embedder] into [bundleDir] (which already holds `data/` + `lib/`),
+  /// preserving the executable bit. Returns the installed binary.
+  Future<File> install(File embedder, Directory bundleDir) async {
+    if (!embedder.existsSync()) {
+      throw RunnableBundleException('embedder not found: ${embedder.path}');
+    }
+    if (!Directory(p.join(bundleDir.path, 'data')).existsSync()) {
+      throw RunnableBundleException(
+        'no Flutter bundle in ${bundleDir.path} (missing data/)',
+      );
+    }
+    final dest = File(p.join(bundleDir.path, p.basename(embedder.path)));
+    embedder.copySync(dest.path);
+    await _run('chmod', ['0755', dest.path]);
+    return dest;
+  }
+
+  /// `tar -czf <dir>.tar.gz` the runnable tree; returns the archive.
+  Future<File> tar(Directory dir) async {
+    final out = File('${dir.path}.tar.gz');
+    final r = await _run('tar', [
+      '-czf',
+      out.path,
+      '-C',
+      dir.parent.path,
+      p.basename(dir.path),
+    ]);
+    if (r.exitCode != 0) {
+      throw RunnableBundleException('tar failed: ${r.stderr}');
+    }
+    return out;
+  }
+}
+
+/// Thrown when assembling or archiving a runnable bundle fails.
+class RunnableBundleException implements Exception {
+  RunnableBundleException(this.message);
+  final String message;
+  @override
+  String toString() => 'RunnableBundleException: $message';
+}

--- a/test/src/cross/runnable_bundle_test.dart
+++ b/test/src/cross/runnable_bundle_test.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:emb_cli/src/cross/runnable_bundle.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tmp;
+  setUp(() => tmp = Directory.systemTemp.createTempSync('emb_run_'));
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  /// A minimal assembled bundle (data/ + lib/), as the pipeline would produce.
+  Directory bundle() {
+    final b = Directory(p.join(tmp.path, 'runnable'));
+    File(p.join(b.path, 'data', 'flutter_assets', 'x'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync('a');
+    File(p.join(b.path, 'data', 'icudtl.dat')).createSync(recursive: true);
+    File(
+      p.join(b.path, 'lib', 'libflutter_engine.so'),
+    ).createSync(recursive: true);
+    return b;
+  }
+
+  File embedder() =>
+      File(p.join(tmp.path, 'homescreen'))
+        ..writeAsBytesSync([0x7f, 0x45, 0x4c, 0x46]);
+
+  test(
+    'install drops the embedder beside data/ and makes it executable',
+    () async {
+      final b = bundle();
+      final bin = await RunnableBundle().install(embedder(), b);
+
+      expect(bin.path, p.join(b.path, 'homescreen'));
+      expect(bin.existsSync(), isTrue);
+      // 0755 — owner-executable at least.
+      expect(bin.statSync().mode & 0x40, isNot(0));
+    },
+  );
+
+  test('install rejects a dir with no Flutter bundle', () async {
+    final empty = Directory(p.join(tmp.path, 'empty'))..createSync();
+    expect(
+      () => RunnableBundle().install(embedder(), empty),
+      throwsA(isA<RunnableBundleException>()),
+    );
+  });
+
+  test('install rejects a missing embedder', () async {
+    expect(
+      () => RunnableBundle().install(File(p.join(tmp.path, 'nope')), bundle()),
+      throwsA(isA<RunnableBundleException>()),
+    );
+  });
+
+  test('tar produces a .tar.gz of the tree', () async {
+    final b = bundle();
+    await RunnableBundle().install(embedder(), b);
+    final archive = await RunnableBundle().tar(b);
+
+    expect(archive.path, '${b.path}.tar.gz');
+    expect(archive.existsSync(), isTrue);
+    expect(archive.lengthSync(), greaterThan(0));
+  });
+}


### PR DESCRIPTION
## Summary

`emb cross --build` produces the cross-built embedder binary, but that alone
can't run — ivi-homescreen needs a Flutter app bundle (engine + assets + AOT)
beside it. This adds `--app` to do both and combine them into a single runnable
tree.

```sh
emb cross ./app/ivi-homescreen --target rpi5 --build \
    --app ./app/flutter-wonderous-app --mode release --tar
```

Output, per built backend, under `<buildRoot>/runnable[-<backend>]/`:

```text
homescreen                       # the cross-built embedder
data/flutter_assets/ …
data/icudtl.dat
lib/libapp.so                    # AOT app (profile/release)
lib/libflutter_engine.so         # target-arch engine
```

Runnable on the target as `./homescreen --b=.`.

## How it works

- `--app <dir>` (with `--build`) builds the Flutter app for the target arch,
  reusing the existing bundle pipeline (`buildAndAssemble`): it fetches the
  engine SDK for (mode, arch) when missing, runs the AOT (`gen_snapshot` →
  `libapp.so`) for profile/release, and assembles `data/` + `lib/`.
- The cross-built embedder is then dropped beside it (one runnable tree per
  backend; the app bundle is built once and copied per backend).
- `-m/--mode` selects `debug`/`profile`/`release` (default `release`).
- `--tar` also emits a `.tar.gz` of each runnable tree.

New `RunnableBundle` assembler (install the embedder + tar), and the engine /
AOT / bundle builders are injected via factories for testing.

## Validation

- Hermetic unit tests for `RunnableBundle` (install drops the binary +
  preserves the exec bit; rejects a missing embedder or a dir with no bundle;
  tar produces a non-empty archive).
- End-to-end: a native `--target local` ivi-homescreen embedder + a wonderous
  `release` bundle assembled into a complete runnable x86-64 tree (`homescreen`
  + `data/flutter_assets` + `data/icudtl.dat` + `lib/libapp.so` +
  `lib/libflutter_engine.so`) and a 62 MB `.tar.gz`.
- `dart analyze` clean, `dart format` clean, `cspell` clean; full suite green
  (192 tests).

## Follow-up

Deploying the runnable tree to a board over SSH (and running it) is a separate
change.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
