### PR TITLE
feat(cross): --deploy rsyncs the runnable bundle to a board over SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,9 @@ emb cross <package-dir|manifest.yaml> [options]
 | `--app <dir>` | — | With `--build`: also build this Flutter app for the target and assemble a **runnable bundle** (embedder + engine + flutter_assets + icudtl + libapp), runnable as `./homescreen --b=.`. |
 | `-m`, `--mode <mode>` | `release` | Runtime mode for the `--app` bundle (`debug`/`profile`/`release`). |
 | `--tar` | off | Also produce a `.tar.gz` of each runnable bundle. |
+| `--deploy <user@host>` | — | With `--app`: rsync each runnable bundle to the board over SSH (port/opts reused from `cross.sysroot` when device-sourced). |
+| `--deploy-dir <path>` | `ivi-homescreen` | Remote destination dir for `--deploy`. |
+| `--run` | off | After `--deploy`, run the bundle on the target over SSH (`./homescreen --b=.`). |
 | `--clean` | off | Remove this target's build + overlay dirs (keeps the toolchain + sysroot), then exit. |
 | `--clean-all` | off | Also remove the downloaded / extracted toolchain + sysroot and the apt / deb caches, then exit. |
 

--- a/lib/src/commands/cross_command.dart
+++ b/lib/src/commands/cross_command.dart
@@ -11,6 +11,7 @@ import 'package:emb_cli/src/cross/cross_profile.dart';
 import 'package:emb_cli/src/cross/cross_provider.dart';
 import 'package:emb_cli/src/cross/cross_target.dart';
 import 'package:emb_cli/src/cross/deb_packager.dart';
+import 'package:emb_cli/src/cross/deployer.dart';
 import 'package:emb_cli/src/cross/local_cross_provider.dart';
 import 'package:emb_cli/src/cross/overlay_builder.dart';
 import 'package:emb_cli/src/cross/runnable_bundle.dart';
@@ -124,6 +125,22 @@ class CrossCommand extends Command<int> {
       ..addFlag(
         'tar',
         help: 'Also produce a .tar.gz of each runnable bundle.',
+        negatable: false,
+      )
+      ..addOption(
+        'deploy',
+        help:
+            'With --app: rsync each runnable bundle to <user@host> over SSH '
+            '(SSH port/opts reused from cross.sysroot when device-sourced).',
+      )
+      ..addOption(
+        'deploy-dir',
+        defaultsTo: 'ivi-homescreen',
+        help: 'Remote destination dir for --deploy.',
+      )
+      ..addFlag(
+        'run',
+        help: 'After --deploy, run the bundle on the target over SSH.',
         negatable: false,
       );
   }
@@ -300,6 +317,9 @@ class CrossCommand extends Command<int> {
         appPath: args['app'] as String?,
         mode: args['mode'] as String,
         tar: args['tar'] == true,
+        deployHost: args['deploy'] as String?,
+        deployDir: args['deploy-dir'] as String,
+        run: args['run'] == true,
       );
     }
     return ExitCode.success.code;
@@ -363,6 +383,9 @@ class CrossCommand extends Command<int> {
     String? appPath,
     String mode = 'release',
     bool tar = false,
+    String? deployHost,
+    String deployDir = 'ivi-homescreen',
+    bool run = false,
   }) async {
     final source =
         FileSystemEntity.typeSync(inputPath) == FileSystemEntityType.file
@@ -435,6 +458,10 @@ class CrossCommand extends Command<int> {
     final built = results.where((r) => r.success).toList();
 
     // Assemble a runnable bundle (embedder + engine + assets + libapp).
+    if (deployHost != null && appPath == null) {
+      _logger.err('--deploy needs --app (no runnable bundle to send).');
+      return ExitCode.usage.code;
+    }
     if (appPath != null) {
       final rc = await _runnable(
         profile,
@@ -446,6 +473,9 @@ class CrossCommand extends Command<int> {
         appPath: appPath,
         mode: mode,
         tar: tar,
+        deployHost: deployHost,
+        deployDir: deployDir,
+        run: run,
       );
       if (rc != ExitCode.success.code) return rc;
     }
@@ -541,6 +571,9 @@ class CrossCommand extends Command<int> {
     required String appPath,
     required String mode,
     required bool tar,
+    String? deployHost,
+    String deployDir = 'ivi-homescreen',
+    bool run = false,
   }) async {
     final arch = EngineArtifacts.engineArch(archOfTriple(profile.targetTriple));
 
@@ -593,12 +626,74 @@ class CrossCommand extends Command<int> {
           final archive = await runnable.tar(outDir);
           _logger.info('  ${r.backend ?? ""}: ${archive.path}');
         }
+        if (deployHost != null) {
+          final dest = multi ? '$deployDir/${r.backend}' : deployDir;
+          final rc = await _deploy(
+            outDir,
+            binName: p.basename(bin.path),
+            host: deployHost,
+            destDir: dest,
+            spec: target.sysroot,
+            // Auto-run only makes sense for a single embedder.
+            run: run && built.length == 1,
+          );
+          if (rc != ExitCode.success.code) return rc;
+        }
       } on RunnableBundleException catch (e) {
         _logger.err('  ${r.backend ?? ""}: ${e.message}');
         return ExitCode.software.code;
       }
     }
     return ExitCode.success.code;
+  }
+
+  /// rsync [outDir] to [host]:[destDir] over SSH, then optionally run the
+  /// embedder there. SSH port/opts come from a device-sourced [spec].
+  Future<int> _deploy(
+    Directory outDir, {
+    required String binName,
+    required String host,
+    required String destDir,
+    required SysrootSpec? spec,
+    required bool run,
+  }) async {
+    final deployer = Deployer();
+    final device = spec?.source == SysrootProvenance.device;
+    final port = device ? spec!.sshPort : 22;
+    final opts = device ? spec!.sshOpts : null;
+
+    final progress = _logger.progress('Deploying → $host:$destDir');
+    final res = await deployer.push(
+      outDir,
+      host: host,
+      destDir: destDir,
+      port: port,
+      opts: opts,
+    );
+    if (!res.success) {
+      progress.fail(res.message ?? 'deploy failed');
+      return ExitCode.software.code;
+    }
+    progress.complete('Deployed → $host:$destDir');
+    final runCmd = './$binName --b=.';
+    if (!run) {
+      _logger.info('  run on target: ssh $host "cd $destDir && $runCmd"');
+      return ExitCode.success.code;
+    }
+    _logger.info('  running on $host …');
+    final argv = deployer.runArgv(
+      host,
+      destDir,
+      runCmd,
+      port: port,
+      opts: opts,
+    );
+    final proc = await Process.start(
+      argv.first,
+      argv.sublist(1),
+      mode: ProcessStartMode.inheritStdio,
+    );
+    return proc.exitCode;
   }
 
   /// Recursively copy the contents of [src] into [dst] (preserving symlinks +

--- a/lib/src/cross/deployer.dart
+++ b/lib/src/cross/deployer.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:emb_cli/src/cross/process_runner.dart';
+
+/// Outcome of a deploy push.
+class DeployResult {
+  const DeployResult({required this.success, this.message});
+  final bool success;
+  final String? message;
+}
+
+/// rsync a runnable bundle to a board over SSH and (optionally) run it. All
+/// SSH/rsync invocation goes through the injectable [ProcessRunner] seam, so
+/// the argv is unit-tested without a real board.
+class Deployer {
+  Deployer({ProcessRunner runProcess = defaultProcessRunner})
+    : _run = runProcess;
+
+  final ProcessRunner _run;
+
+  /// rsync `<localDir>/` → `<host>:<destDir>/` — archive, compress,
+  /// delete-extraneous. [host] is `user@host`; [port] / [opts] tune SSH.
+  Future<DeployResult> push(
+    Directory localDir, {
+    required String host,
+    required String destDir,
+    int port = 22,
+    String? opts,
+  }) async {
+    // rsync won't create the remote parent dirs; do it first.
+    final mk = await _run('ssh', [
+      ..._sshArgs(port, opts),
+      host,
+      'mkdir -p ${_shQuote(destDir)}',
+    ]);
+    if (mk.exitCode != 0) {
+      return DeployResult(success: false, message: 'ssh mkdir: ${mk.stderr}');
+    }
+    final r = await _run('rsync', [
+      '-az',
+      '--delete',
+      '-e',
+      _sshTransport(port, opts),
+      _slash(localDir.path),
+      '$host:${_slash(destDir)}',
+    ]);
+    return DeployResult(
+      success: r.exitCode == 0,
+      message: r.exitCode == 0 ? null : 'rsync: ${r.stderr}',
+    );
+  }
+
+  /// The argv for running [command] in [destDir] on [host] over SSH (consumed
+  /// by `--run`, which streams it).
+  List<String> runArgv(
+    String host,
+    String destDir,
+    String command, {
+    int port = 22,
+    String? opts,
+  }) => [
+    'ssh',
+    ..._sshArgs(port, opts),
+    host,
+    'cd ${_shQuote(destDir)} && $command',
+  ];
+
+  List<String> _sshArgs(int port, String? opts) => [
+    if (port != 22) ...['-p', '$port'],
+    if (opts != null && opts.trim().isNotEmpty)
+      ...opts.trim().split(RegExp(r'\s+')),
+  ];
+
+  /// rsync's `-e` transport string.
+  String _sshTransport(int port, String? opts) => [
+    'ssh',
+    if (port != 22) '-p $port',
+    if (opts != null && opts.trim().isNotEmpty) opts.trim(),
+  ].join(' ');
+
+  String _slash(String path) => path.endsWith('/') ? path : '$path/';
+  String _shQuote(String s) => "'${s.replaceAll("'", r"'\''")}'";
+}

--- a/test/src/cross/deployer_test.dart
+++ b/test/src/cross/deployer_test.dart
@@ -1,0 +1,101 @@
+import 'dart:io';
+
+import 'package:emb_cli/src/cross/deployer.dart';
+import 'package:test/test.dart';
+
+({
+  Future<ProcessResult> Function(
+    String,
+    List<String>, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment,
+    bool runInShell,
+  })
+  run,
+  List<List<String>> calls,
+})
+recorder({bool Function(String exe)? failOn}) {
+  final calls = <List<String>>[];
+  Future<ProcessResult> run(
+    String exe,
+    List<String> args, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+  }) async {
+    calls.add([exe, ...args]);
+    return ProcessResult(0, (failOn?.call(exe) ?? false) ? 1 : 0, '', 'boom');
+  }
+
+  return (run: run, calls: calls);
+}
+
+void main() {
+  late Directory tmp;
+  setUp(() => tmp = Directory.systemTemp.createTempSync('emb_dep_'));
+  tearDown(() => tmp.deleteSync(recursive: true));
+
+  test(
+    'push mkdirs the remote dir then rsyncs over the ssh transport',
+    () async {
+      final rec = recorder();
+      final r = await Deployer(runProcess: rec.run).push(
+        tmp,
+        host: 'pi@board',
+        destDir: 'ivi-homescreen',
+        port: 2222,
+        opts: '-o StrictHostKeyChecking=no',
+      );
+      expect(r.success, isTrue);
+
+      final ssh = rec.calls.firstWhere((c) => c.first == 'ssh');
+      expect(ssh, containsAllInOrder(['ssh', '-p', '2222']));
+      expect(ssh, contains('pi@board'));
+      expect(ssh.last, contains("mkdir -p 'ivi-homescreen'"));
+
+      final rsync = rec.calls.firstWhere((c) => c.first == 'rsync');
+      expect(rsync, containsAllInOrder(['-az', '--delete']));
+      final e = rsync[rsync.indexOf('-e') + 1];
+      expect(e, 'ssh -p 2222 -o StrictHostKeyChecking=no');
+      expect(rsync, contains('${tmp.path}/'));
+      expect(rsync, contains('pi@board:ivi-homescreen/'));
+    },
+  );
+
+  test('default port omits -p and uses a plain ssh transport', () async {
+    final rec = recorder();
+    await Deployer(
+      runProcess: rec.run,
+    ).push(tmp, host: 'pi@board', destDir: 'app');
+    final rsync = rec.calls.firstWhere((c) => c.first == 'rsync');
+    expect(rsync[rsync.indexOf('-e') + 1], 'ssh');
+    expect(rsync.any((a) => a == '-p'), isFalse);
+  });
+
+  test('push reports failure when rsync fails', () async {
+    final rec = recorder(failOn: (exe) => exe == 'rsync');
+    final r = await Deployer(
+      runProcess: rec.run,
+    ).push(tmp, host: 'pi@board', destDir: 'app');
+    expect(r.success, isFalse);
+    expect(r.message, contains('rsync'));
+  });
+
+  test('runArgv builds the remote run command', () {
+    final argv = Deployer().runArgv(
+      'pi@board',
+      'ivi-homescreen',
+      './homescreen --b=.',
+      port: 2222,
+    );
+    expect(argv, [
+      'ssh',
+      '-p',
+      '2222',
+      'pi@board',
+      "cd 'ivi-homescreen' && ./homescreen --b=.",
+    ]);
+  });
+}


### PR DESCRIPTION
## Summary

Completes the cross workflow: after assembling a runnable bundle (`--app`),
send it to the target board over SSH and optionally run it.

```sh
emb cross ./app/ivi-homescreen --target rpi5 --build \
    --app ./app/flutter-wonderous-app --mode release \
    --deploy ubuntu@board --run
```

End to end: cross-build the embedder, build the app bundle (engine + AOT +
assets), assemble the runnable tree, **rsync it to the board**, and run it.

## What's added

- **`--deploy <user@host>`** (with `--app`) — rsync each runnable bundle to the
  board: it `mkdir -p`s the remote dir first, then
  `rsync -az --delete -e 'ssh …'`. SSH port/opts are reused from
  `cross.sysroot` when the target is device-sourced.
- **`--deploy-dir <path>`** — remote destination (default `ivi-homescreen`).
  Multiple backends deploy to `<dir>/<backend>`.
- **`--run`** — after deploy, run `./homescreen --b=.` in the destination over
  SSH (single backend). Output is streamed.
- `--deploy` without `--app` is a usage error (nothing to send).

A new `Deployer` (`push` + `runArgv`) drives rsync/ssh through the injectable
`ProcessRunner` seam.

## Validation

- Hermetic tests cover the argv and SSH transport: the remote `mkdir`, the
  `rsync -az --delete` line, the `-e 'ssh -p <port> <opts>'` transport, the
  default-port case (plain `ssh`, no `-p`), a failure surfacing, and the
  `runArgv` remote command.
- End-to-end with a real SSH/rsync round-trip: build → assemble → deploy to a
  local SSH endpoint, with all five pieces (`homescreen`, `data/flutter_assets`,
  `data/icudtl.dat`, `lib/libapp.so`, `lib/libflutter_engine.so`) landing on the
  remote.
- `dart analyze` clean, `dart format` clean, `cspell` clean; full suite green
  (197 tests).

## Note

`--run` of a DRM-KMS embedder over a plain SSH session needs DRM-master / seat
access on the board (e.g. stop the display manager, or use a seat-managed
login). The rsync deploy itself has no such requirement.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
